### PR TITLE
chore(ffi): fix compile errors and warnings

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -61,9 +61,6 @@ pub use self::http_types::*;
 pub use self::io::*;
 pub use self::task::*;
 
-pub(crate) use self::body::UserBody;
-pub(crate) use self::http_types::{HeaderCaseMap, ReasonPhrase};
-
 /// Return in iter functions to continue iterating.
 pub const HYPER_ITER_CONTINUE: libc::c_int = 0;
 /// Return in iter functions to stop iterating.


### PR DESCRIPTION
As I understand it, "cargo rustc" in gen_header.sh generates a ton of
errors, but still manages to generate an object that can be used by
cbindgen to generate hyper.h.

However, I tried to make a separate change to add more fields to
hyper.h, and learned that "cargo rustc" stops if it reaches 50 errors,
which I reached. I was able to buy some headroom and fix a number of
the compilation errors by adding imports to the fake Cargo.toml we
generate in gen_header.sh.

I wasn't sure how to resolve imports like "crate::Result" which appear
to reference the top-level src/error.rs, and print an error when they
are compiled in gen_header.sh. But I only need to buy headroom under
the 50 error count for now, which I was able to do by adding the
imports.

It is possible that someone more familiar with Rust than me could look
at this and know what to change to get the total number of errors to
zero.

